### PR TITLE
DOT Exporter: add new utils to export graph in DOT format

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,7 @@ declare(strict_types=1);
 
 namespace Application;
 
-use Velkuns\GameTextEngine\Api\Items;
-use Velkuns\GameTextEngine\Api\Loader\JsonLoader;
-use Velkuns\GameTextEngine\Api\Player;
-use Velunns\GameTextEngine\Api\GameApi
+use Velkuns\GameTextEngine\Api\Items;use Velkuns\GameTextEngine\Api\Player;use Velkuns\GameTextEngine\Util\Loader\JsonLoader;use Velunns\GameTextEngine\Api\GameApi;
 
 //~ Factories
 $modifierFactory  = new ModifierFactory();
@@ -83,7 +80,7 @@ declare(strict_types=1);
 
 namespace Application;
 
-use Velkuns\GameTextEngine\Api\Loader\JsonLoader;
+use Velkuns\GameTextEngine\Util\Loader\JsonLoader;
 
 $loader  = new JsonLoader();
 

--- a/data/stories/graph.dot
+++ b/data/stories/graph.dot
@@ -1,0 +1,22 @@
+digraph story {
+
+  node [shape=box,style=rounded]
+
+  text_1 [label="Marie vous salue de la main.\n \n Vous vous engagez sur la route, en direction des champs qui bordent le village.\n Vous voici maintenant aventurier. Enfin, un aventurier qui débute.\n \n Votre coeur tamb..."]
+  text_2 [label="2 chemin s'offre à vous..."]
+  text_3 [label="Vous vous enfoncez dans la forêt, et vous tombez sur un loup au détour du chemin..."]
+  text_4 [label="Vous décidez de combattre le loup! Préparez-vous..."]
+  text_5 [label="Vous avancez sur le chemin et devant vous se dresse une sombre masure. Vous vous approchez de la porte..."]
+  text_997 [label="Vous avez vaincu la menace! Vous retournez au village en héros."]
+  text_998 [label="Vous êtes mort..."]
+  text_999 [label="Fin de l'histoire Test"]
+
+  text_1 -> text_2 [label="Continuer"]
+  text_2 -> text_3 [label="Prendre le chemin de droite"]
+  text_2 -> text_5 [label="Prendre le chemin de gauche"]
+  text_3 -> text_4 [label="Combattre"]
+  text_4 -> text_997 [label="Vous avez vaincu!"]
+  text_4 -> text_998 [label="Vous êtes mort..."]
+  text_3 -> text_999 [label="Fuir"]
+  text_5 -> text_999 [label="Fuir"]
+}

--- a/src/Api/Combat.php
+++ b/src/Api/Combat.php
@@ -41,7 +41,8 @@ readonly class Combat
             } while ($player->isAlive());
 
             if (!$player->isAlive()) {
-                break; // stop combat if player is dead
+                //~ stop combat if player is dead
+                break; // @codeCoverageIgnore
             }
         }
 

--- a/src/Api/GameApi.php
+++ b/src/Api/GameApi.php
@@ -12,10 +12,10 @@ declare(strict_types=1);
 namespace Velkuns\GameTextEngine\Api;
 
 use Velkuns\GameTextEngine\Api\Exception\GameException;
-use Velkuns\GameTextEngine\Api\Loader\JsonLoader;
 use Velkuns\GameTextEngine\Element\Entity\EntityInterface;
 use Velkuns\GameTextEngine\Element\Item\ItemInterface;
 use Velkuns\GameTextEngine\Graph\Graph;
+use Velkuns\GameTextEngine\Utils\Loader\JsonLoader;
 
 /**
  * @phpstan-import-type GraphData from Graph

--- a/src/Graph/Graph.php
+++ b/src/Graph/Graph.php
@@ -54,6 +54,22 @@ class Graph implements \JsonSerializable
         return $this->edgesFromSource[$source] ?? [];
     }
 
+    /**
+     * @return array<string, Node>
+     */
+    public function getAllNodes(): array
+    {
+        return $this->nodes;
+    }
+
+    /**
+     * @return array<string, Edge>
+     */
+    public function getAllEdges(): array
+    {
+        return $this->edges;
+    }
+
     public function addNode(Node $node): self
     {
         if (isset($this->nodes[$node->id])) {

--- a/src/Utils/Exception/ExporterException.php
+++ b/src/Utils/Exception/ExporterException.php
@@ -9,6 +9,6 @@
 
 declare(strict_types=1);
 
-namespace Velkuns\GameTextEngine\Api\Exception;
+namespace Velkuns\GameTextEngine\Utils\Exception;
 
-class LoaderException extends \RuntimeException {}
+class ExporterException extends \RuntimeException {}

--- a/src/Utils/Exception/LoaderException.php
+++ b/src/Utils/Exception/LoaderException.php
@@ -1,0 +1,14 @@
+<?php
+
+/*
+ * Copyright (c) Romain Cottard
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Velkuns\GameTextEngine\Utils\Exception;
+
+class LoaderException extends \RuntimeException {}

--- a/src/Utils/Exporter/DOTExporter.php
+++ b/src/Utils/Exporter/DOTExporter.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * Copyright (c) Romain Cottard
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Velkuns\GameTextEngine\Utils\Exporter;
+
+use Velkuns\GameTextEngine\Graph\Graph;
+use Velkuns\GameTextEngine\Utils\Exception\ExporterException;
+
+readonly class DOTExporter
+{
+    public function toString(Graph $graph): string
+    {
+        $content = "digraph story {\n\n";
+
+        $content .= "  node [shape=box,style=rounded]\n\n";
+
+        foreach ($graph->getAllNodes() as $node) {
+            $label    = $this->cleanText($node->content, 200);
+            $content .= "  $node->id [label=\"$label\"]\n";
+        }
+
+        $content .= "\n";
+
+        foreach ($graph->getAllEdges() as $edge) {
+            $label    = $this->cleanText($edge->content, 30);
+            $content .= "  $edge->source -> $edge->target [label=\"$label\"]\n";
+        }
+
+        $content .= "}\n";
+
+        return $content;
+    }
+
+    /**
+     * @codeCoverageIgnore
+     */
+    public function toFile(Graph $graph, string $filePathname): self
+    {
+        $result = \file_put_contents($filePathname, $this->toString($graph));
+
+        if ($result === false) {
+            throw new ExporterException("Unable to write file $filePathname! Is directory exists and writable ?");
+        }
+
+        return $this;
+    }
+
+    private function cleanText(string $text, int $length): string
+    {
+        if (strlen($text) > $length) {
+            $text = substr($text, 0, $length) . '...'; // @codeCoverageIgnore
+        }
+        return \str_replace(['"', "\n"], ['\"', '\n'], $text);
+    }
+}

--- a/src/Utils/Loader/JsonLoader.php
+++ b/src/Utils/Loader/JsonLoader.php
@@ -8,9 +8,9 @@
  */
 declare(strict_types=1);
 
-namespace Velkuns\GameTextEngine\Api\Loader;
+namespace Velkuns\GameTextEngine\Utils\Loader;
 
-use Velkuns\GameTextEngine\Api\Exception\LoaderException;
+use Velkuns\GameTextEngine\Utils\Exception\LoaderException;
 
 readonly class JsonLoader
 {

--- a/tests/Helper/ApiTrait.php
+++ b/tests/Helper/ApiTrait.php
@@ -13,8 +13,8 @@ namespace Velkuns\GameTextEngine\Tests\Helper;
 
 use Velkuns\GameTextEngine\Api\Bestiary;
 use Velkuns\GameTextEngine\Api\Items;
-use Velkuns\GameTextEngine\Api\Loader\JsonLoader;
 use Velkuns\GameTextEngine\Element\Item\ItemInterface;
+use Velkuns\GameTextEngine\Utils\Loader\JsonLoader;
 
 /**
  * @phpstan-import-type BestiaryData from Bestiary

--- a/tests/Helper/GraphTrait.php
+++ b/tests/Helper/GraphTrait.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * Copyright (c) Romain Cottard
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Velkuns\GameTextEngine\Tests\Helper;
+
+use Velkuns\GameTextEngine\Graph\Edge;
+use Velkuns\GameTextEngine\Graph\Graph;
+use Velkuns\GameTextEngine\Graph\Node;
+
+trait GraphTrait
+{
+    private static function getComplexGraph(): Graph
+    {
+        $graph = new Graph('Test Graph');
+
+        $node1 = new Node('text_1', 'Start');
+        $node2 = new Node('text_2', '2 -> 3, 2 -> 5');
+        $node3 = new Node('text_3', '3 -> 4');
+        $node4 = new Node('text_4', '4 -> Death, 4 -> End');
+        $node5 = new Node('text_5', '5 -> End');
+        $node8 = new Node('text_8', 'Death');
+        $node9 = new Node('text_9', 'End');
+
+        $edge1_2 = new Edge('text_1', 'text_2', 'Continue to 2');
+        $edge2_3 = new Edge('text_2', 'text_3', 'Continue to 3');
+        $edge3_4 = new Edge('text_3', 'text_4', 'Continue to 4');
+        $edge4_8 = new Edge('text_4', 'text_8', 'Continue to death');
+        $edge4_9 = new Edge('text_4', 'text_9', 'Continue to end');
+        $edge2_5 = new Edge('text_2', 'text_5', 'Continue to 5');
+        $edge5_9 = new Edge('text_5', 'text_9', 'Continue to end');
+
+        //~ Add all nodes
+        $graph->addNode($node1);
+        $graph->addNode($node2);
+        $graph->addNode($node3);
+        $graph->addNode($node4);
+        $graph->addNode($node5);
+        $graph->addNode($node8);
+        $graph->addNode($node9);
+
+        //~ Add all edges
+        $graph->addEdge($edge1_2);
+        $graph->addEdge($edge2_3);
+        $graph->addEdge($edge3_4);
+        $graph->addEdge($edge4_8);
+        $graph->addEdge($edge4_9);
+        $graph->addEdge($edge2_5);
+        $graph->addEdge($edge5_9);
+
+        return $graph;
+    }
+}

--- a/tests/Integration/Api/BestiaryTest.php
+++ b/tests/Integration/Api/BestiaryTest.php
@@ -10,13 +10,13 @@ declare(strict_types=1);
 
 namespace Velkuns\GameTextEngine\Tests\Integration\Api;
 
-use Velkuns\GameTextEngine\Api\Bestiary;
 use PHPUnit\Framework\TestCase;
+use Velkuns\GameTextEngine\Api\Bestiary;
 use Velkuns\GameTextEngine\Api\Exception\BestiaryException;
 use Velkuns\GameTextEngine\Api\Items;
-use Velkuns\GameTextEngine\Api\Loader\JsonLoader;
 use Velkuns\GameTextEngine\Element\Item\ItemInterface;
 use Velkuns\GameTextEngine\Tests\Helper\FactoryTrait;
+use Velkuns\GameTextEngine\Utils\Loader\JsonLoader;
 
 /**
  * @phpstan-import-type ItemData from ItemInterface

--- a/tests/Integration/Api/GameApiTest.php
+++ b/tests/Integration/Api/GameApiTest.php
@@ -11,13 +11,13 @@ declare(strict_types=1);
 
 namespace Api;
 
+use PHPUnit\Framework\TestCase;
 use Random\Engine\Mt19937;
 use Random\Randomizer;
 use Velkuns\GameTextEngine\Api\Bestiary;
 use Velkuns\GameTextEngine\Api\Combat;
 use Velkuns\GameTextEngine\Api\GameApi;
 use Velkuns\GameTextEngine\Api\Items;
-use Velkuns\GameTextEngine\Api\Loader\JsonLoader;
 use Velkuns\GameTextEngine\Api\Player;
 use Velkuns\GameTextEngine\Api\Story;
 use Velkuns\GameTextEngine\Element\Entity\EntityInterface;
@@ -25,7 +25,7 @@ use Velkuns\GameTextEngine\Element\Item\ItemInterface;
 use Velkuns\GameTextEngine\Graph\Graph;
 use Velkuns\GameTextEngine\Tests\Helper\EntityTrait;
 use Velkuns\GameTextEngine\Tests\Helper\FactoryTrait;
-use PHPUnit\Framework\TestCase;
+use Velkuns\GameTextEngine\Utils\Loader\JsonLoader;
 
 /**
  * @phpstan-import-type GraphData from Graph

--- a/tests/Integration/Api/ItemsTest.php
+++ b/tests/Integration/Api/ItemsTest.php
@@ -10,13 +10,13 @@ declare(strict_types=1);
 
 namespace Velkuns\GameTextEngine\Tests\Integration\Api;
 
-use Velkuns\GameTextEngine\Api\Bestiary;
 use PHPUnit\Framework\TestCase;
+use Velkuns\GameTextEngine\Api\Bestiary;
 use Velkuns\GameTextEngine\Api\Exception\ItemException;
 use Velkuns\GameTextEngine\Api\Items;
-use Velkuns\GameTextEngine\Api\Loader\JsonLoader;
 use Velkuns\GameTextEngine\Element\Item\ItemInterface;
 use Velkuns\GameTextEngine\Tests\Helper\FactoryTrait;
+use Velkuns\GameTextEngine\Utils\Loader\JsonLoader;
 
 /**
  * @phpstan-import-type ItemData from ItemInterface

--- a/tests/Integration/Api/PlayerTest.php
+++ b/tests/Integration/Api/PlayerTest.php
@@ -10,13 +10,13 @@ declare(strict_types=1);
 
 namespace Velkuns\GameTextEngine\Tests\Integration\Api;
 
-use Velkuns\GameTextEngine\Api\Items;
-use Velkuns\GameTextEngine\Api\Loader\JsonLoader;
-use Velkuns\GameTextEngine\Api\Player;
 use PHPUnit\Framework\TestCase;
+use Velkuns\GameTextEngine\Api\Items;
+use Velkuns\GameTextEngine\Api\Player;
 use Velkuns\GameTextEngine\Element\Item\ItemInterface;
 use Velkuns\GameTextEngine\Tests\Helper\EntityTrait;
 use Velkuns\GameTextEngine\Tests\Helper\FactoryTrait;
+use Velkuns\GameTextEngine\Utils\Loader\JsonLoader;
 
 /**
  * @phpstan-import-type ItemData from ItemInterface

--- a/tests/Integration/Api/StoryTest.php
+++ b/tests/Integration/Api/StoryTest.php
@@ -10,13 +10,13 @@ declare(strict_types=1);
 
 namespace Velkuns\GameTextEngine\Tests\Integration\Api;
 
+use PHPUnit\Framework\TestCase;
 use Velkuns\GameTextEngine\Api\Exception\StoryException;
-use Velkuns\GameTextEngine\Api\Loader\JsonLoader;
 use Velkuns\GameTextEngine\Api\Story;
 use Velkuns\GameTextEngine\Graph\Graph;
 use Velkuns\GameTextEngine\Tests\Helper\EntityTrait;
 use Velkuns\GameTextEngine\Tests\Helper\FactoryTrait;
-use PHPUnit\Framework\TestCase;
+use Velkuns\GameTextEngine\Utils\Loader\JsonLoader;
 
 /**
  * @phpstan-import-type GraphData from Graph

--- a/tests/Integration/Utils/Exporter/DOTExporterTest.php
+++ b/tests/Integration/Utils/Exporter/DOTExporterTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * Copyright (c) Romain Cottard
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Velkuns\GameTextEngine\Tests\Integration\Utils\Exporter;
+
+use PHPUnit\Framework\TestCase;
+use Velkuns\GameTextEngine\Tests\Helper\GraphTrait;
+use Velkuns\GameTextEngine\Utils\Exporter\DOTExporter;
+
+class DOTExporterTest extends TestCase
+{
+    use GraphTrait;
+
+    public function testExportString(): void
+    {
+        $expected = 'digraph story {
+
+  node [shape=box,style=rounded]
+
+  text_1 [label="Start"]
+  text_2 [label="2 -> 3, 2 -> 5"]
+  text_3 [label="3 -> 4"]
+  text_4 [label="4 -> Death, 4 -> End"]
+  text_5 [label="5 -> End"]
+  text_8 [label="Death"]
+  text_9 [label="End"]
+
+  text_1 -> text_2 [label="Continue to 2"]
+  text_2 -> text_3 [label="Continue to 3"]
+  text_3 -> text_4 [label="Continue to 4"]
+  text_4 -> text_8 [label="Continue to death"]
+  text_4 -> text_9 [label="Continue to end"]
+  text_2 -> text_5 [label="Continue to 5"]
+  text_5 -> text_9 [label="Continue to end"]
+}
+';
+
+        $graph    = self::getComplexGraph();
+        $exporter = new DOTExporter();
+
+        $export = $exporter->toString($graph);
+
+        self::assertSame($expected, $export);
+    }
+}

--- a/tests/Integration/Utils/Loader/JsonLoaderTest.php
+++ b/tests/Integration/Utils/Loader/JsonLoaderTest.php
@@ -6,14 +6,15 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
 declare(strict_types=1);
 
-namespace Velkuns\GameTextEngine\Tests\Integration\Api\Loader;
+namespace Velkuns\GameTextEngine\Tests\Integration\Utils\Loader;
 
-use Velkuns\GameTextEngine\Api\Exception\LoaderException;
-use Velkuns\GameTextEngine\Api\Loader\JsonLoader;
 use PHPUnit\Framework\TestCase;
 use Velkuns\GameTextEngine\Element\Item\ItemInterface;
+use Velkuns\GameTextEngine\Utils\Exception\LoaderException;
+use Velkuns\GameTextEngine\Utils\Loader\JsonLoader;
 
 /**
  * @phpstan-import-type ItemData from ItemInterface

--- a/tests/Unit/Graph/GraphTest.php
+++ b/tests/Unit/Graph/GraphTest.php
@@ -10,13 +10,13 @@ declare(strict_types=1);
 
 namespace Velkuns\GameTextEngine\Tests\Unit\Graph;
 
-use Velkuns\GameTextEngine\Api\Loader\JsonLoader;
+use PHPUnit\Framework\TestCase;
 use Velkuns\GameTextEngine\Graph\Edge;
 use Velkuns\GameTextEngine\Graph\Exception\GraphException;
 use Velkuns\GameTextEngine\Graph\Graph;
 use Velkuns\GameTextEngine\Graph\Node;
 use Velkuns\GameTextEngine\Tests\Helper\FactoryTrait;
-use PHPUnit\Framework\TestCase;
+use Velkuns\GameTextEngine\Tests\Helper\GraphTrait;
 
 /**
  * @phpstan-import-type GraphData from Graph
@@ -24,6 +24,7 @@ use PHPUnit\Framework\TestCase;
 class GraphTest extends TestCase
 {
     use FactoryTrait;
+    use GraphTrait;
 
     public function testGraph(): void
     {
@@ -81,41 +82,7 @@ class GraphTest extends TestCase
 
     public function testRemoveNode(): void
     {
-        $graph = new Graph('Test Graph');
-
-        $node1 = new Node('text_1', 'Start');
-        $node2 = new Node('text_2', '2 -> 3, 2 -> 5');
-        $node3 = new Node('text_3', '3 -> 4');
-        $node4 = new Node('text_4', '4 -> Death, 4 -> End');
-        $node5 = new Node('text_5', '5 -> End');
-        $node8 = new Node('text_8', 'Death');
-        $node9 = new Node('text_9', 'End');
-
-        $edge1_2 = new Edge('text_1', 'text_2', 'Continue to 2');
-        $edge2_3 = new Edge('text_2', 'text_3', 'Continue to 3');
-        $edge3_4 = new Edge('text_3', 'text_4', 'Continue to 4');
-        $edge4_8 = new Edge('text_4', 'text_8', 'Continue to death');
-        $edge4_9 = new Edge('text_4', 'text_9', 'Continue to end');
-        $edge2_5 = new Edge('text_2', 'text_5', 'Continue to 5');
-        $edge5_9 = new Edge('text_2', 'text_9', 'Continue to end');
-
-        //~ Add all nodes
-        $graph->addNode($node1);
-        $graph->addNode($node2);
-        $graph->addNode($node3);
-        $graph->addNode($node4);
-        $graph->addNode($node5);
-        $graph->addNode($node8);
-        $graph->addNode($node9);
-
-        //~ Add all edges
-        $graph->addEdge($edge1_2);
-        $graph->addEdge($edge2_3);
-        $graph->addEdge($edge3_4);
-        $graph->addEdge($edge4_8);
-        $graph->addEdge($edge4_9);
-        $graph->addEdge($edge2_5);
-        $graph->addEdge($edge5_9);
+        $graph = self::getComplexGraph();
 
         $expectedBefore = [
             'metadata' => ['title' => 'Test Graph',],
@@ -135,7 +102,7 @@ class GraphTest extends TestCase
                 ['source' => 'text_4', 'target' => 'text_8', 'label'  => 'action', 'metadata' => ['text' => 'Continue to death']],
                 ['source' => 'text_4', 'target' => 'text_9', 'label'  => 'action', 'metadata' => ['text' => 'Continue to end']],
                 ['source' => 'text_2', 'target' => 'text_5', 'label'  => 'action', 'metadata' => ['text' => 'Continue to 5']],
-                ['source' => 'text_2', 'target' => 'text_9', 'label'  => 'action', 'metadata' => ['text' => 'Continue to end']],
+                ['source' => 'text_5', 'target' => 'text_9', 'label'  => 'action', 'metadata' => ['text' => 'Continue to end']],
             ],
         ];
 
@@ -153,7 +120,7 @@ class GraphTest extends TestCase
                 ['source' => 'text_1', 'target' => 'text_2', 'label'  => 'action', 'metadata' => ['text' => 'Continue to 2']],
                 ['source' => 'text_2', 'target' => 'text_3', 'label'  => 'action', 'metadata' => ['text' => 'Continue to 3']],
                 ['source' => 'text_2', 'target' => 'text_5', 'label'  => 'action', 'metadata' => ['text' => 'Continue to 5']],
-                ['source' => 'text_2', 'target' => 'text_9', 'label'  => 'action', 'metadata' => ['text' => 'Continue to end']],
+                ['source' => 'text_5', 'target' => 'text_9', 'label'  => 'action', 'metadata' => ['text' => 'Continue to end']],
             ],
         ];
 
@@ -171,7 +138,7 @@ class GraphTest extends TestCase
             'edges' => [
                 ['source' => 'text_1', 'target' => 'text_2', 'label'  => 'action', 'metadata' => ['text' => 'Continue to 2']],
                 ['source' => 'text_2', 'target' => 'text_5', 'label'  => 'action', 'metadata' => ['text' => 'Continue to 5']],
-                ['source' => 'text_2', 'target' => 'text_9', 'label'  => 'action', 'metadata' => ['text' => 'Continue to end']],
+                ['source' => 'text_5', 'target' => 'text_9', 'label'  => 'action', 'metadata' => ['text' => 'Continue to end']],
             ],
         ];
 


### PR DESCRIPTION
DOTExporter:
 - Can export graph in DOT format (string or directly in file)
 - Add tests

Graph:
 - Add methods getAllNodes() and getAllEdges() for DOT Exporter

Global:
- Move JsonLoader in src/Utils rather than src/Api/
- Update use according to the changes