### PR TITLE
API: add set() & remove() methods in Bestiary and Items

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ namespace Application;
 
 //~ Get an item by its name
 $item = $game->items->get('Rusty Sword');
+
+$staff = $itemFactory->from(['name' => 'Staff', ...]);
+$gameApi->items->set($staff); // Adds or replaces the item in the items dictionary
+$gameApi->items->remove($staff->getName()); // Removes the item from the items dictionary
 ```
 
 ### Bestiary dictionary
@@ -120,6 +124,10 @@ namespace Application;
 
 //~ Get a creature by its name
 $entity = $gameApi->bestiary->get('Goblin');
+
+$goblinWarrior = $entityFactory->from(['name' => 'Goblin Warrior', ...]);
+$gameApi->bestiary->set($goblinWarrior); // Adds or replaces the creature in the bestiary
+$gameApi->bestiary->remove('Goblin'); // Removes the creature from the bestiary
 ```
 
 ### Story API

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
   },
 
   "require-dev": {
-    "friendsofphp/php-cs-fixer": "^3.89.0",
+    "friendsofphp/php-cs-fixer": "^3.89.1",
     "phpstan/phpstan": "^2.1.31",
     "phpstan/phpstan-strict-rules": "^2.0.7",
     "phpstan/phpstan-deprecation-rules": "^2.0.3",

--- a/src/Api/Items.php
+++ b/src/Api/Items.php
@@ -42,10 +42,27 @@ class Items
     {
         $lowerCaseName = \strtolower($name);
         if (!isset($this->items[$lowerCaseName])) {
-            throw new ItemException("Item '$name' not found in item list.");
+            throw new ItemException("Item '$name' not found in item list.", 1601);
         }
 
         return $asClone ? clone $this->items[$lowerCaseName] : $this->items[$lowerCaseName];
+    }
+
+    public function set(ItemInterface $item): self
+    {
+        $this->items[\strtolower($item->getName())] = $item;
+
+        return $this;
+    }
+
+    public function remove(string $name): self
+    {
+        $lowerCaseName = \strtolower($name);
+        if (isset($this->items[$lowerCaseName])) {
+            unset($this->items[$lowerCaseName]);
+        }
+
+        return $this;
     }
 
     public function dump(bool $prettyPrint = false): string

--- a/src/Element/Entity/EntityInterface.php
+++ b/src/Element/Entity/EntityInterface.php
@@ -55,4 +55,9 @@ interface EntityInterface extends \JsonSerializable
     public function getModifiers(EntityInterface $enemy): array;
 
     public function clone(): self;
+
+    /**
+     * @return EntityData
+     */
+    public function jsonSerialize(): array;
 }

--- a/tests/Integration/Api/ItemsTest.php
+++ b/tests/Integration/Api/ItemsTest.php
@@ -43,6 +43,40 @@ class ItemsTest extends TestCase
         self::assertSame('sword', $item->getSubType());
     }
 
+    public function testAndAndRemoveItem(): void
+    {
+        $dataDir = (string) realpath(__DIR__ . '/../../../data');
+        $loader  = new JsonLoader();
+        $items   = new Items(self::getItemFactory());
+
+        /** @var list<ItemData> $itemsData */
+        $itemsData = $loader->fromFile($dataDir . '/items.json');
+        $items->load($itemsData);
+
+        $staff = self::getItemFactory()->from([
+            'name'        => 'Staff',
+            'type'        => 'weapon',
+            'subType'     => 'staff',
+            'description' => 'A basic wooden staff.',
+            'modifiers'   => [],
+            'flags'       => 6,
+            'equipped'    => false,
+            'damages'     => 2,
+            'price'       => 0,
+        ]);
+
+        $items->set($staff);
+        self::assertSame($staff, $items->get('Staff', false));
+
+        //~ Remove item
+        $items->remove($staff->getName());
+
+        self::expectException(ItemException::class);
+        self::expectExceptionCode(1601);
+
+        $items->get($staff->getName());
+    }
+
     public function testLoadWhenThrowException(): void
     {
         $dataDir = (string) realpath(__DIR__ . '/../../../data');


### PR DESCRIPTION
Bestiary API:
- Add `set()` & `remove()` methods to set or remove an entity from bestiary
- Update `README`
- Update tests

Items API:
- Add `set()` & `remove()` methods to set or remove an item from items list
- Update `README`
- Update tests