### PR TITLE
Abilities API + add Api suffix to other API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,29 +16,3 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ```
 
 ----
-
-## [1.1.0] - 2023-03-15
-### Changed
-- Update Makefile
-- Update CI GitHub Action
-- Update composer.json
-- Now compatible with PHP 8.2
-
-## [1.0.2] - 2022-11-13
-### Changed
-- Update Makefile
-- Update CI GitHub Action
-- Update composer.json
-
-## [1.0.1] - 2022-06-12
-### Changed
-- Fix changelog template link
-- Update github workflow ci file
-
-## [1.0.0] - 2022-06-12
-### Added
-- Add phpstan for static analyze & php compatibility
-- Add Check compatibility with PHP 7.4 & 8.1 in CI
-- Add Makefile & .dist files for CI
-- Add Dummy Source & Dummy Test
-- Add GitHub CI file & sonar project file

--- a/data/rules/rules_abilities.json
+++ b/data/rules/rules_abilities.json
@@ -1,7 +1,7 @@
 {
     "description": "This section defines base and compound abilities for characters.\n\nThe system is based on four primary base abilities: strength, endurance, agility, and intuition. Each base ability has an initial value of 10 and a maximum value of 20.\n\nCompound abilities are derived from base abilities. For example, the 'attack' compound ability is calculated as the sum of strength and agility, while the 'defense' compound ability is calculated as the sum of endurance and intuition.\n\nAbilities values are constrained within defined limits to ensure balanced gameplay.\n\nMedium values are 10, and are between 0 and 20.",
-    "attribution_points": 10,
-    "attribution_points_max_per_ability": 5,
+    "attributionPoints": 10,
+    "attributionPointsMaxPerAbility": 5,
     "bases": {
         "strength": {
             "type": "base",
@@ -68,14 +68,12 @@
         "attack": {
             "type": "compound",
             "name": "attack",
-            "rule": "strength + agility",
-            "description": "Calculates attack ability as the sum of strength and agility."
+            "rule": "strength + agility"
         },
         "defense": {
             "type": "compound",
             "name": "defense",
-            "rule": "endurance + intuition",
-            "description": "Calculates defense ability as the sum of endurance and intuition."
+            "rule": "endurance + intuition"
         }
     }
 }

--- a/src/Api/AbilitiesApi.php
+++ b/src/Api/AbilitiesApi.php
@@ -1,0 +1,199 @@
+<?php
+
+/*
+ * Copyright (c) Romain Cottard
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Velkuns\GameTextEngine\Api;
+
+use Velkuns\GameTextEngine\Api\Exception\AbilitiesApiException;
+use Velkuns\GameTextEngine\Element\Ability\AbilityInterface;
+use Velkuns\GameTextEngine\Element\Ability\BaseAbility;
+use Velkuns\GameTextEngine\Element\Ability\CompoundAbility;
+use Velkuns\GameTextEngine\Element\Entity\EntityAbilities;
+use Velkuns\GameTextEngine\Element\Factory\AbilityFactory;
+
+/**
+ * @phpstan-import-type BaseAbilityData from BaseAbility
+ * @phpstan-import-type CompoundAbilityData from CompoundAbility
+ * @phpstan-import-type AbilitiesData from EntityAbilities
+ * @phpstan-type AbilitiesRulesData array{
+ *    description: string,
+ *    attributionPoints: int,
+ *    attributionPointsMaxPerAbility: 5,
+ *    bases: array<string, BaseAbilityData>,
+ *    compounds: array<string, CompoundAbilityData>,
+ * }
+ */
+class AbilitiesApi
+{
+    public string $description = '';
+    public int $attributionPoints = 0;
+    public int $attributionPointsMaxPerAbility = 0;
+
+    /** @var array<string, BaseAbility> $baseAbilities */
+    public array $baseAbilities = [];
+
+    /** @var array<string, CompoundAbility> */
+    public array $compoundAbilities = [];
+
+    public function __construct(
+        private readonly AbilityFactory $abilityFactory,
+    ) {}
+
+    /**
+     * @phpstan-param AbilitiesRulesData $data
+     */
+    public function load(array $data): void
+    {
+        $this->description                    = $data['description'];
+        $this->attributionPoints              = $data['attributionPoints'];
+        $this->attributionPointsMaxPerAbility = $data['attributionPointsMaxPerAbility'];
+
+        $this->baseAbilities     = $this->abilityFactory->fromBases($data['bases']);
+        $this->compoundAbilities = $this->abilityFactory->fromCompounds($data['compounds'], $this->baseAbilities);
+    }
+
+    public function get(string $name, bool $asClone = true): ?AbilityInterface
+    {
+        $ability = $this->baseAbilities[$name] ?? $this->compoundAbilities[$name] ?? null;
+
+        if ($ability !== null && $asClone) {
+            return $ability->clone();
+        }
+
+        return $ability;
+    }
+
+    public function set(AbilityInterface $ability): self
+    {
+        if ($ability instanceof BaseAbility) {
+            $this->baseAbilities[$ability->getName()] = $ability;
+        } elseif ($ability instanceof CompoundAbility) {
+            $this->compoundAbilities[$ability->getName()] = $ability;
+        }
+
+        return $this;
+    }
+
+    public function remove(string $name): self
+    {
+        if (isset($this->baseAbilities[$name])) {
+            unset($this->baseAbilities[$name]);
+        } elseif (isset($this->compoundAbilities[$name])) {
+            unset($this->compoundAbilities[$name]);
+        } else {
+            throw new AbilitiesApiException("The ability '$name' does not exist.", 1450);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param array<string, int> $data
+     * @phpstan-return AbilitiesData
+     */
+    public function fromNewPlayer(array $data): array
+    {
+        $abilities = ['bases' => [], 'compounds' => []];
+
+        /** @var array<string, BaseAbilityData> $basesWithInitRule */
+        $basesWithInitRule = [];
+        /** @var array<string, BaseAbilityData> $basesWithInitRule */
+        $bases = [];
+
+        //~ Transform abilities into data and separate bases with ou without init rule.
+        foreach ($this->baseAbilities as $name => $ability) {
+            if ($ability->getRule() !== null) {
+                //~ Reset values before store ability with init rule
+                $basesWithInitRule[$name] = ['initial' => 0, 'max' => 0, 'value' => 0] + $ability->jsonSerialize();
+            } else {
+                $bases[$name] = $ability->jsonSerialize();
+            }
+        }
+
+        //~ Then, iterate on new player data abilities
+        $totalAttributedPoints = 0;
+        foreach ($data as $name => $value) {
+            $ability = $bases[$name] ?? null;
+            if ($ability === null) {
+                throw new AbilitiesApiException("The ability '$name' does not exist.", 1451);
+            }
+
+            if ($value - $ability['value'] > $this->attributionPointsMaxPerAbility) {
+                throw new AbilitiesApiException("You cannot attribute more than $this->attributionPointsMaxPerAbility per ability.", 1452);
+            }
+
+            if ($value < $ability['value']) {
+                throw new AbilitiesApiException("You cannot have less point that base define for an ability.", 1453);
+            }
+
+            $totalAttributedPoints += $value - $ability['value'];
+
+            //~ Set appropriate values
+            $ability['initial'] = $value;
+            $ability['max']     = $value;
+            $ability['value']   = $value;
+
+            //~ Then create
+            $abilities['bases'][$name] = $ability;
+        }
+
+        $remainingPoints = $this->attributionPoints - $totalAttributedPoints;
+        if ($remainingPoints < 0) {
+            throw new AbilitiesApiException("You cannot attribute more than $this->attributionPoints in total.", 1454);
+        }
+
+        if ($remainingPoints > 0) {
+            throw new AbilitiesApiException("You have still have some point(s) to attribute (remaining: $remainingPoints).", 1455);
+        }
+
+        //~ Then add base abilities with init rule
+        foreach ($basesWithInitRule as $name => $ability) {
+            $abilities['bases'][$name] = $ability;
+        }
+
+        //~ Then add compound abilities
+        foreach ($this->compoundAbilities as $name => $ability) {
+            $abilities['compounds'][$name] = $ability->jsonSerialize();
+        }
+
+        return $abilities;
+    }
+
+    public function dump(bool $prettyPrint = false): string
+    {
+        //~ Before dump, we need to reset initial/max/value for ability with init rule.
+        $baseAbilities = $this->baseAbilities;
+        foreach ($baseAbilities as $ability) {
+            if ($ability->getRule() === null) {
+                continue;
+            }
+
+            $ability->value   = 0;
+            $ability->initial = 0;
+            $ability->max     = 0;
+        }
+
+        try {
+            $data = [
+                'description'                    => $this->description,
+                'attributionPoints'              => $this->attributionPoints,
+                'attributionPointsMaxPerAbility' => $this->attributionPointsMaxPerAbility,
+                'bases'                          => $baseAbilities,
+                'compounds'                      => $this->compoundAbilities,
+            ];
+
+            return \json_encode($data, flags: \JSON_THROW_ON_ERROR | ($prettyPrint ? \JSON_PRETTY_PRINT : 0));
+            // @codeCoverageIgnoreStart
+        } catch (\JsonException $exception) {
+            throw new AbilitiesApiException('Unable to dump abilities rules data: ' . $exception->getMessage(), 1451, $exception);
+        }
+        // @codeCoverageIgnoreEnd
+    }
+}

--- a/src/Api/BestiaryApi.php
+++ b/src/Api/BestiaryApi.php
@@ -29,14 +29,14 @@ use Velkuns\GameTextEngine\Element\Factory\EntityFactory;
  *    damages?: DamagesData|null,
  * }
  */
-class Bestiary
+class BestiaryApi
 {
     /** @var array<string, EntityInterface> $bestiary */
     private array $bestiary = [];
 
     public function __construct(
         private readonly EntityFactory $entityFactory,
-        private readonly Items $items,
+        private readonly ItemsApi $items,
     ) {}
 
     /**

--- a/src/Api/CombatApi.php
+++ b/src/Api/CombatApi.php
@@ -18,7 +18,7 @@ use Velkuns\GameTextEngine\Utils\Log\CombatLog;
 /**
  * @phpstan-type TurnLogData array{player: CombatLog, enemy?: CombatLog}
  */
-readonly class Combat
+readonly class CombatApi
 {
     public function __construct(
         private Randomizer $randomizer,

--- a/src/Api/Exception/AbilitiesApiException.php
+++ b/src/Api/Exception/AbilitiesApiException.php
@@ -1,0 +1,14 @@
+<?php
+
+/*
+ * Copyright (c) Romain Cottard
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Velkuns\GameTextEngine\Api\Exception;
+
+class AbilitiesApiException extends \RuntimeException {}

--- a/src/Api/GameApi.php
+++ b/src/Api/GameApi.php
@@ -15,37 +15,48 @@ use Velkuns\GameTextEngine\Api\Exception\GameException;
 use Velkuns\GameTextEngine\Element\Entity\EntityInterface;
 use Velkuns\GameTextEngine\Element\Item\ItemInterface;
 use Velkuns\GameTextEngine\Graph\Graph;
+use Velkuns\GameTextEngine\Utils\Exporter\DOTExporter;
 use Velkuns\GameTextEngine\Utils\Loader\JsonLoader;
 
 /**
  * @phpstan-import-type GraphData from Graph
  * @phpstan-import-type ItemData from ItemInterface
- * @phpstan-import-type BestiaryData from Bestiary
+ * @phpstan-import-type BestiaryData from BestiaryApi
  * @phpstan-import-type EntityData from EntityInterface
+ * @phpstan-import-type AbilitiesRulesData from AbilitiesApi
  */
-class GameApi
+readonly class GameApi
 {
     public function __construct(
-        public readonly JsonLoader $loader,
-        public readonly Story $story,
-        public readonly Items $items,
-        public readonly Bestiary $bestiary,
-        public readonly Player $player,
-        public readonly Combat $combat,
+        public JsonLoader $loader,
+        public DOTExporter $exporter,
+        public StoryApi $storyApi,
+        public ItemsApi $itemsApi,
+        public BestiaryApi $bestiaryApi,
+        public AbilitiesApi $abilitiesApi,
+        public PlayerApi $playerApi,
+        public CombatApi $combatApi,
     ) {}
 
     /**
      * @phpstan-param GraphData $storyData
      * @phpstan-param list<ItemData> $itemsData
      * @phpstan-param list<BestiaryData> $bestiaryData
+     * @phpstan-param AbilitiesRulesData $abilitiesRulesData
      * @phpstan-param EntityData $playerData
      */
-    public function load(array $storyData, array $itemsData, array $bestiaryData, array $playerData): self
-    {
-        $this->story->load($storyData);
-        $this->items->load($itemsData);
-        $this->bestiary->load($bestiaryData);
-        $this->player->load($playerData);
+    public function load(
+        array $storyData,
+        array $itemsData,
+        array $bestiaryData,
+        array $abilitiesRulesData,
+        array $playerData,
+    ): self {
+        $this->storyApi->load($storyData);
+        $this->itemsApi->load($itemsData);
+        $this->bestiaryApi->load($bestiaryData);
+        $this->abilitiesApi->load($abilitiesRulesData);
+        $this->playerApi->load($playerData);
 
         return $this;
     }
@@ -55,6 +66,7 @@ class GameApi
      *     story: string,
      *     items: string,
      *     bestiary: string,
+     *     abilities: string,
      *     player: string,
      * }
      */
@@ -62,10 +74,11 @@ class GameApi
     {
         try {
             return [
-                'story'    => $this->story->dump($prettyPrint),
-                'items'    => $this->items->dump($prettyPrint),
-                'bestiary' => $this->bestiary->dump($prettyPrint),
-                'player'   => $this->player->dump($prettyPrint),
+                'story'     => $this->storyApi->dump($prettyPrint),
+                'items'     => $this->itemsApi->dump($prettyPrint),
+                'bestiary'  => $this->bestiaryApi->dump($prettyPrint),
+                'abilities' => $this->abilitiesApi->dump($prettyPrint),
+                'player'    => $this->playerApi->dump($prettyPrint),
             ];
             // @codeCoverageIgnoreStart
         } catch (\Throwable $exception) {

--- a/src/Api/ItemsApi.php
+++ b/src/Api/ItemsApi.php
@@ -17,7 +17,7 @@ use Velkuns\GameTextEngine\Element\Item\ItemInterface;
 /**
  * @phpstan-import-type ItemData from ItemInterface
  */
-class Items
+class ItemsApi
 {
     /** @var array<string, ItemInterface> $items */
     private array $items = [];

--- a/src/Api/PlayerApi.php
+++ b/src/Api/PlayerApi.php
@@ -6,6 +6,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
 declare(strict_types=1);
 
 namespace Velkuns\GameTextEngine\Api;
@@ -28,13 +29,14 @@ use Velkuns\GameTextEngine\Element\Modifier\ModifierProcessor;
  *    inventory?: list<string>,
  * }
  */
-class Player
+class PlayerApi
 {
     public EntityInterface $player;
 
     public function __construct(
         private readonly EntityFactory $entityFactory,
-        private readonly Items $items,
+        private readonly ItemsApi $items,
+        private readonly AbilitiesApi $abilitiesApi,
         private readonly ModifierProcessor $modifierProcessor,
     ) {}
 
@@ -107,29 +109,7 @@ class Player
         ];
 
         //~ Build abilities
-        $abilities = ['bases' => [], 'compounds' => []];
-        foreach ($data['abilities'] as $name => $value) {
-            $abilities['bases'][$name] = [
-                'type'        => 'base',
-                'name'        => $name,
-                'initial'     => $value,
-                'max'         => $value,
-                'value'       => $value,
-                'constraints' => ['min' => 0, 'max' => 20],
-                'rule'        => null,
-            ];
-        }
-        $abilities['bases']['vitality']    = [
-            'type'        => 'base',
-            'name'        => 'vitality',
-            'initial'     => 0,
-            'max'         => 0,
-            'value'       => 0,
-            'constraints' => ['min' => 0, 'max' => 40],
-            'rule'        => 'strength + endurance',
-        ];
-        $abilities['compounds']['attack']  = ['type' => 'compound', 'name' => 'attack', 'rule' => 'strength + agility'];
-        $abilities['compounds']['defense'] = ['type' => 'compound', 'name' => 'defense', 'rule' => 'endurance + intuition'];
+        $abilities = $this->abilitiesApi->fromNewPlayer($data['abilities']);
 
         //~ Initialize empty statuses
         $statuses = [

--- a/src/Api/StoryApi.php
+++ b/src/Api/StoryApi.php
@@ -20,7 +20,7 @@ use Velkuns\GameTextEngine\Graph\Node;
 /**
  * @phpstan-import-type GraphData from Graph
  */
-class Story
+class StoryApi
 {
     public Graph $graph;
 

--- a/tests/Integration/Api/AbilitiesApiTest.php
+++ b/tests/Integration/Api/AbilitiesApiTest.php
@@ -1,0 +1,181 @@
+<?php
+
+/*
+ * Copyright (c) Romain Cottard
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Velkuns\GameTextEngine\Tests\Integration\Api;
+
+use PHPUnit\Framework\TestCase;
+use Velkuns\GameTextEngine\Api\AbilitiesApi;
+use Velkuns\GameTextEngine\Api\Exception\AbilitiesApiException;
+use Velkuns\GameTextEngine\Element\Ability\BaseAbility;
+use Velkuns\GameTextEngine\Element\Ability\CompoundAbility;
+use Velkuns\GameTextEngine\Tests\Helper\FactoryTrait;
+use Velkuns\GameTextEngine\Utils\Loader\JsonLoader;
+
+/**
+ * @phpstan-import-type AbilitiesRulesData from AbilitiesApi
+ */
+class AbilitiesApiTest extends TestCase
+{
+    use FactoryTrait;
+
+    public function testLoad(): void
+    {
+        $api = $this->getApi();
+
+        self::assertSame("This section defines base and compound abilities for characters.
+
+The system is based on four primary base abilities: strength, endurance, agility, and intuition. Each base ability has an initial value of 10 and a maximum value of 20.
+
+Compound abilities are derived from base abilities. For example, the 'attack' compound ability is calculated as the sum of strength and agility, while the 'defense' compound ability is calculated as the sum of endurance and intuition.
+
+Abilities values are constrained within defined limits to ensure balanced gameplay.
+
+Medium values are 10, and are between 0 and 20.", $api->description);
+        self::assertSame(10, $api->attributionPoints);
+        self::assertSame(5, $api->attributionPointsMaxPerAbility);
+    }
+
+    public function testDump(): void
+    {
+        $api = $this->getApi();
+        $content = (string) \file_get_contents($this->getDataDir() . '/rules/rules_abilities.json');
+
+        self::assertSame(\trim($content), $api->dump(true));
+    }
+
+    public function testGetAndSetAndRemove(): void
+    {
+        $api = $this->getApi();
+
+        $baseAbility     = new BaseAbility('test', value: 12, initial: 12);
+        $api->set($baseAbility);
+        $compoundAbility = new CompoundAbility('test_compound', 'test + strength', $api->baseAbilities);
+        $api->set($compoundAbility);
+
+        self::assertSame($baseAbility, $api->get('test', false));
+        self::assertSame($compoundAbility, $api->get('test_compound', false));
+        self::assertNotSame($baseAbility, $api->get('test'));
+        self::assertNotSame($compoundAbility, $api->get('test_compound'));
+        self::assertEquals($baseAbility, $api->get('test'));
+        self::assertEquals($compoundAbility, $api->get('test_compound'));
+
+        $api->remove('test_compound');
+        self::assertNull($api->get('test_compound'));
+        $api->remove('test');
+        self::assertNull($api->get('test'));
+
+        self::expectException(AbilitiesApiException::class);
+        self::expectExceptionCode(1450);
+        $api->remove('test');
+    }
+
+    public function testFromNewPlayerButHaveUnknowAbility(): void
+    {
+        $api = $this->getApi();
+
+        $abilities = [
+            'strength'  => 10,
+            'endurance' => 10,
+            'agility'   => 10,
+            'intuition' => 10,
+            'unknown'   => 10,
+        ];
+
+        self::expectException(AbilitiesApiException::class);
+        self::expectExceptionCode(1451);
+
+        $api->fromNewPlayer($abilities);
+    }
+
+    public function testFromNewPlayerButAbilityValueAttributedIsMoreThanDefinedInRules(): void
+    {
+        $api = $this->getApi();
+
+        $abilities = [
+            'strength'  => 10,
+            'endurance' => 10,
+            'agility'   => 10,
+            'intuition' => 16,
+        ];
+
+        self::expectException(AbilitiesApiException::class);
+        self::expectExceptionCode(1452);
+
+        $api->fromNewPlayer($abilities);
+    }
+
+    public function testFromNewPlayerButAbilityValueIsLowerThanBaseDefined(): void
+    {
+        $api = $this->getApi();
+
+        $abilities = [
+            'strength'  => 10,
+            'endurance' => 10,
+            'agility'   => 10,
+            'intuition' => 8,
+        ];
+
+        self::expectException(AbilitiesApiException::class);
+        self::expectExceptionCode(1453);
+
+        $api->fromNewPlayer($abilities);
+    }
+
+    public function testFromNewPlayerButTotalAttributedPointsIsMoreThanDefinedInRules(): void
+    {
+        $api = $this->getApi();
+
+        $abilities = [
+            'strength'  => 15,
+            'endurance' => 15,
+            'agility'   => 15,
+            'intuition' => 15,
+        ];
+
+        self::expectException(AbilitiesApiException::class);
+        self::expectExceptionCode(1454);
+
+        $api->fromNewPlayer($abilities);
+    }
+
+    public function testFromNewPlayerButItIsRemainingSomePointsToAttribute(): void
+    {
+        $api = $this->getApi();
+
+        $abilities = [
+            'strength'  => 12,
+            'endurance' => 12,
+            'agility'   => 12,
+            'intuition' => 12,
+        ];
+
+        self::expectException(AbilitiesApiException::class);
+        self::expectExceptionCode(1455);
+
+        $api->fromNewPlayer($abilities);
+    }
+
+    private function getApi(): AbilitiesApi
+    {
+        $loader  = new JsonLoader();
+        $api     = new AbilitiesApi(self::getAbilityFactory());
+
+        /** @var AbilitiesRulesData $data */
+        $data = $loader->fromFile($this->getDataDir() . '/rules/rules_abilities.json');
+        $api->load($data);
+
+        return $api;
+    }
+
+    private function getDataDir(): string
+    {
+        return (string) realpath(__DIR__ . '/../../../data');
+    }
+}

--- a/tests/Integration/Api/BestiaryApiTest.php
+++ b/tests/Integration/Api/BestiaryApiTest.php
@@ -11,18 +11,18 @@ declare(strict_types=1);
 namespace Velkuns\GameTextEngine\Tests\Integration\Api;
 
 use PHPUnit\Framework\TestCase;
-use Velkuns\GameTextEngine\Api\Bestiary;
+use Velkuns\GameTextEngine\Api\BestiaryApi;
 use Velkuns\GameTextEngine\Api\Exception\BestiaryException;
-use Velkuns\GameTextEngine\Api\Items;
+use Velkuns\GameTextEngine\Api\ItemsApi;
 use Velkuns\GameTextEngine\Element\Item\ItemInterface;
 use Velkuns\GameTextEngine\Tests\Helper\FactoryTrait;
 use Velkuns\GameTextEngine\Utils\Loader\JsonLoader;
 
 /**
  * @phpstan-import-type ItemData from ItemInterface
- * @phpstan-import-type BestiaryData from Bestiary
+ * @phpstan-import-type BestiaryData from BestiaryApi
  */
-class BestiaryTest extends TestCase
+class BestiaryApiTest extends TestCase
 {
     use FactoryTrait;
 
@@ -30,13 +30,13 @@ class BestiaryTest extends TestCase
     {
         $dataDir = (string) realpath(__DIR__ . '/../../../data');
         $loader  = new JsonLoader();
-        $items   = new Items(self::getItemFactory());
+        $items   = new ItemsApi(self::getItemFactory());
 
         /** @var list<ItemData> $itemsData */
         $itemsData = $loader->fromFile($dataDir . '/items.json');
         $items->load($itemsData);
 
-        $bestiary = new Bestiary(self::getEntityFactory(), $items);
+        $bestiary = new BestiaryApi(self::getEntityFactory(), $items);
 
         /** @var list<BestiaryData> $bestiaryData */
         $bestiaryData = $loader->fromFile($dataDir . '/bestiary.json');
@@ -52,13 +52,13 @@ class BestiaryTest extends TestCase
     {
         $dataDir = (string) realpath(__DIR__ . '/../../../data');
         $loader  = new JsonLoader();
-        $items   = new Items(self::getItemFactory());
+        $items   = new ItemsApi(self::getItemFactory());
 
         /** @var list<ItemData> $itemsData */
         $itemsData = $loader->fromFile($dataDir . '/items.json');
         $items->load($itemsData);
 
-        $bestiary = new Bestiary(self::getEntityFactory(), $items);
+        $bestiary = new BestiaryApi(self::getEntityFactory(), $items);
 
         /** @var list<BestiaryData> $bestiaryData */
         $bestiaryData = $loader->fromFile($dataDir . '/bestiary.json');
@@ -94,13 +94,13 @@ class BestiaryTest extends TestCase
     {
         $dataDir = (string) realpath(__DIR__ . '/../../../data');
         $loader  = new JsonLoader();
-        $items   = new Items(self::getItemFactory());
+        $items   = new ItemsApi(self::getItemFactory());
 
         /** @var list<ItemData> $itemsData */
         $itemsData = $loader->fromFile($dataDir . '/items.json');
         $items->load($itemsData);
 
-        $bestiary = new Bestiary(self::getEntityFactory(), $items);
+        $bestiary = new BestiaryApi(self::getEntityFactory(), $items);
 
         /** @var list<BestiaryData> $bestiaryData */
         $bestiaryData = $loader->fromFile($dataDir . '/bestiary.json');

--- a/tests/Integration/Api/CombatApiTest.php
+++ b/tests/Integration/Api/CombatApiTest.php
@@ -13,23 +13,23 @@ namespace Velkuns\GameTextEngine\Tests\Integration\Api;
 use PHPUnit\Framework\TestCase;
 use Random\Engine\Mt19937;
 use Random\Randomizer;
-use Velkuns\GameTextEngine\Api\Combat;
+use Velkuns\GameTextEngine\Api\CombatApi;
 use Velkuns\GameTextEngine\Element\Processor\TimeProcessor;
 use Velkuns\GameTextEngine\Tests\Helper\ApiTrait;
 use Velkuns\GameTextEngine\Tests\Helper\EntityTrait;
 
-class CombatTest extends TestCase
+class CombatApiTest extends TestCase
 {
     use ApiTrait;
     use EntityTrait;
 
-    private Combat $combat;
+    private CombatApi $combat;
 
     private const int SEED = 42; // For reproducible tests
 
     public function setUp(): void
     {
-        $this->combat = new Combat(new Randomizer(new Mt19937(self::SEED)), new TimeProcessor());
+        $this->combat = new CombatApi(new Randomizer(new Mt19937(self::SEED)), new TimeProcessor());
     }
 
     public function testCombat1(): void
@@ -83,8 +83,8 @@ class CombatTest extends TestCase
     public function testCombat2(): void
     {
         $player  = self::getPlayer()->clone(); // Player already have rested with remaining turn = 1
-        $rat1    = self::getBestiary()->get('rat'); // get cloned rat
-        $rat2    = self::getBestiary()->get('rat'); // get cloned rat
+        $rat1    = self::getBestiaryApi()->get('rat'); // get cloned rat
+        $rat2    = self::getBestiaryApi()->get('rat'); // get cloned rat
 
         self::assertSame(1, $player->getStatuses()->states['Rested']->getRemainingTurns());
         $this->combat->start($player, [$rat1, $rat2]);

--- a/tests/Integration/Api/ItemsApiTest.php
+++ b/tests/Integration/Api/ItemsApiTest.php
@@ -11,18 +11,18 @@ declare(strict_types=1);
 namespace Velkuns\GameTextEngine\Tests\Integration\Api;
 
 use PHPUnit\Framework\TestCase;
-use Velkuns\GameTextEngine\Api\Bestiary;
+use Velkuns\GameTextEngine\Api\BestiaryApi;
 use Velkuns\GameTextEngine\Api\Exception\ItemException;
-use Velkuns\GameTextEngine\Api\Items;
+use Velkuns\GameTextEngine\Api\ItemsApi;
 use Velkuns\GameTextEngine\Element\Item\ItemInterface;
 use Velkuns\GameTextEngine\Tests\Helper\FactoryTrait;
 use Velkuns\GameTextEngine\Utils\Loader\JsonLoader;
 
 /**
  * @phpstan-import-type ItemData from ItemInterface
- * @phpstan-import-type BestiaryData from Bestiary
+ * @phpstan-import-type BestiaryData from BestiaryApi
  */
-class ItemsTest extends TestCase
+class ItemsApiTest extends TestCase
 {
     use FactoryTrait;
 
@@ -30,7 +30,7 @@ class ItemsTest extends TestCase
     {
         $dataDir = (string) realpath(__DIR__ . '/../../../data');
         $loader  = new JsonLoader();
-        $items   = new Items(self::getItemFactory());
+        $items   = new ItemsApi(self::getItemFactory());
 
         /** @var list<ItemData> $itemsData */
         $itemsData = $loader->fromFile($dataDir . '/items.json');
@@ -47,7 +47,7 @@ class ItemsTest extends TestCase
     {
         $dataDir = (string) realpath(__DIR__ . '/../../../data');
         $loader  = new JsonLoader();
-        $items   = new Items(self::getItemFactory());
+        $items   = new ItemsApi(self::getItemFactory());
 
         /** @var list<ItemData> $itemsData */
         $itemsData = $loader->fromFile($dataDir . '/items.json');
@@ -81,7 +81,7 @@ class ItemsTest extends TestCase
     {
         $dataDir = (string) realpath(__DIR__ . '/../../../data');
         $loader  = new JsonLoader();
-        $items   = new Items(self::getItemFactory());
+        $items   = new ItemsApi(self::getItemFactory());
 
         /** @var list<ItemData> $itemsData */
         $itemsData = $loader->fromFile($dataDir . '/items.json');

--- a/tests/Integration/Api/PlayerApiTest.php
+++ b/tests/Integration/Api/PlayerApiTest.php
@@ -12,11 +12,12 @@ namespace Velkuns\GameTextEngine\Tests\Integration\Api;
 
 use PHPUnit\Framework\TestCase;
 use Velkuns\GameTextEngine\Api\Exception\PlayerException;
-use Velkuns\GameTextEngine\Api\Items;
-use Velkuns\GameTextEngine\Api\Player;
+use Velkuns\GameTextEngine\Api\ItemsApi;
+use Velkuns\GameTextEngine\Api\PlayerApi;
 use Velkuns\GameTextEngine\Element\Item\ItemInterface;
 use Velkuns\GameTextEngine\Element\Modifier\ModifierProcessor;
 use Velkuns\GameTextEngine\Element\Resolver\TypeElementResolver;
+use Velkuns\GameTextEngine\Tests\Helper\ApiTrait;
 use Velkuns\GameTextEngine\Tests\Helper\EntityTrait;
 use Velkuns\GameTextEngine\Tests\Helper\FactoryTrait;
 use Velkuns\GameTextEngine\Utils\Loader\JsonLoader;
@@ -24,21 +25,15 @@ use Velkuns\GameTextEngine\Utils\Loader\JsonLoader;
 /**
  * @phpstan-import-type ItemData from ItemInterface
  */
-class PlayerTest extends TestCase
+class PlayerApiTest extends TestCase
 {
+    use ApiTrait;
     use EntityTrait;
     use FactoryTrait;
 
     public function testNew(): void
     {
-        $dataDir = __DIR__ . '/../../../data';
-        $items   = new Items(self::getItemFactory());
-
-        /** @var list<ItemData> $itemsData */
-        $itemsData = (new JsonLoader())->fromFile($dataDir . '/items.json');
-        $items->load($itemsData);
-
-        $playerApi = new Player(self::getEntityFactory(), $items, new ModifierProcessor(new TypeElementResolver()));
+        $playerApi = self::getPlayerApi();
 
         $newPlayerData = [
             'name'        => 'New Hero',
@@ -65,14 +60,7 @@ class PlayerTest extends TestCase
 
     public function testConsume(): void
     {
-        $dataDir = __DIR__ . '/../../../data';
-        $items   = new Items(self::getItemFactory());
-
-        /** @var list<ItemData> $itemsData */
-        $itemsData = (new JsonLoader())->fromFile($dataDir . '/items.json');
-        $items->load($itemsData);
-
-        $playerApi = new Player(self::getEntityFactory(), $items, new ModifierProcessor(new TypeElementResolver()));
+        $playerApi = self::getPlayerApi();
 
         $newPlayerData = [
             'name'        => 'New Hero',
@@ -105,14 +93,7 @@ class PlayerTest extends TestCase
 
     public function testConsumeButItemNotInInventory(): void
     {
-        $dataDir = __DIR__ . '/../../../data';
-        $items   = new Items(self::getItemFactory());
-
-        /** @var list<ItemData> $itemsData */
-        $itemsData = (new JsonLoader())->fromFile($dataDir . '/items.json');
-        $items->load($itemsData);
-
-        $playerApi = new Player(self::getEntityFactory(), $items, new ModifierProcessor(new TypeElementResolver()));
+        $playerApi = self::getPlayerApi();
 
         $newPlayerData = [
             'name'        => 'New Hero',
@@ -139,14 +120,7 @@ class PlayerTest extends TestCase
 
     public function testConsumeButItemIsNotConsumable(): void
     {
-        $dataDir = __DIR__ . '/../../../data';
-        $items   = new Items(self::getItemFactory());
-
-        /** @var list<ItemData> $itemsData */
-        $itemsData = (new JsonLoader())->fromFile($dataDir . '/items.json');
-        $items->load($itemsData);
-
-        $playerApi = new Player(self::getEntityFactory(), $items, new ModifierProcessor(new TypeElementResolver()));
+        $playerApi = self::getPlayerApi();
 
         $newPlayerData = [
             'name'        => 'New Hero',

--- a/tests/Integration/Api/StoryApiTest.php
+++ b/tests/Integration/Api/StoryApiTest.php
@@ -12,7 +12,7 @@ namespace Velkuns\GameTextEngine\Tests\Integration\Api;
 
 use PHPUnit\Framework\TestCase;
 use Velkuns\GameTextEngine\Api\Exception\StoryException;
-use Velkuns\GameTextEngine\Api\Story;
+use Velkuns\GameTextEngine\Api\StoryApi;
 use Velkuns\GameTextEngine\Graph\Graph;
 use Velkuns\GameTextEngine\Tests\Helper\EntityTrait;
 use Velkuns\GameTextEngine\Tests\Helper\FactoryTrait;
@@ -21,7 +21,7 @@ use Velkuns\GameTextEngine\Utils\Loader\JsonLoader;
 /**
  * @phpstan-import-type GraphData from Graph
  */
-class StoryTest extends TestCase
+class StoryApiTest extends TestCase
 {
     use EntityTrait;
     use FactoryTrait;
@@ -97,7 +97,7 @@ class StoryTest extends TestCase
         self::assertSame('Vous êtes mort...', $edges[0]->content);
     }
 
-    private function getStory(): Story
+    private function getStory(): StoryApi
     {
         $dataDir = __DIR__ . '/../../../data';
         $loader = new JsonLoader();
@@ -105,7 +105,7 @@ class StoryTest extends TestCase
         /** @var GraphData $data */
         $data = $loader->fromFile($dataDir . '/stories/test.json');
 
-        $story = new Story(self::getGraphFactory());
+        $story = new StoryApi(self::getGraphFactory());
         $story->load($data);
 
         return $story;

--- a/tests/Unit/Element/Modifier/ModifierProcessorTest.php
+++ b/tests/Unit/Element/Modifier/ModifierProcessorTest.php
@@ -57,7 +57,7 @@ class ModifierProcessorTest extends TestCase
     public function testApplyButTypeRefersToList(): void
     {
         $player    = self::getPlayer();
-        $player->getInventory()->add(self::getItems()->get('Small Health Potion'));
+        $player->getInventory()->add(self::getItemsApi()->get('Small Health Potion'));
 
         $processor = new ModifierProcessor(new TypeElementResolver());
         $modifier  = new Modifier('self.inventory.items.name', -5);


### PR DESCRIPTION
Abilites API:
- Add new class to handle Abilities Rules (get, set, remove, player creation & validation against rules)
- Add tests

Game API:
- Add Api suffix to GameApi api properties
- Add Abilities API to it
- Add DTOExporter as exporter
- Update tests

Other APIs:
- Add Api suffix when missing (global coherence)
- Update tests classes names according to the changes