### PR TITLE
Game API: fix read when refresh page with trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ----
 
+## [0.2.1] - 2025-10-30
+[0.2.1]: https://github.com/velkuns/game-text-engine/compare/0.1.0...master
+### Added
+- Add ItemInterface::equip() method to equip an item
+### Changed
+- GameApi::read(): if source = target, do not apply the trigger (already be applied)
+- Fix story test on condition for edge
+
 ## [0.2.0] - 2025-10-30
 [0.2.0]: https://github.com/velkuns/game-text-engine/compare/0.1.0...master
 ### Added

--- a/data/stories/test.json
+++ b/data/stories/test.json
@@ -97,8 +97,8 @@
                     "numberRequired": 1,
                     "conditions": [
                         {
-                            "type": "enemy.abilities.vitality",
-                            "condition": "value<=0",
+                            "type": "self.abilities.vitality",
+                            "condition": "value>0",
                             "is": true
                         }
                     ]

--- a/src/Api/GameApi.php
+++ b/src/Api/GameApi.php
@@ -161,7 +161,7 @@ readonly class GameApi
         $node = $this->story->goto($source, $target, $this->player->player);
 
         //~ Handle trigger if necessary
-        if ($node->trigger !== null && isset($node->trigger['combat'])) {
+        if ($source !== $target && $node->trigger !== null && isset($node->trigger['combat'])) {
             $enemies = [];
             foreach ($node->trigger['combat']['enemies'] as $name) {
                 $enemies[] = $this->bestiary->get($name);

--- a/src/Element/Item/Item.php
+++ b/src/Element/Item/Item.php
@@ -29,7 +29,7 @@ class Item implements ItemInterface
         private readonly string $description = '',
         private readonly array $modifiers = [],
         private readonly int $flags = 0,
-        private readonly bool $equipped = false,
+        private bool $equipped = false,
         private readonly Damages $damages = new Damages(),
         private int $quantity = 1,
         private readonly int $price = 0,
@@ -112,6 +112,13 @@ class Item implements ItemInterface
     private function isItemType(int $flag): bool
     {
         return ($this->flags & $flag) === $flag;
+    }
+
+    public function equip(): self
+    {
+        $this->equipped = true;
+
+        return $this;
     }
 
     public function setQuantity(int $quantity): self

--- a/src/Element/Item/ItemInterface.php
+++ b/src/Element/Item/ItemInterface.php
@@ -65,6 +65,8 @@ interface ItemInterface extends \JsonSerializable
 
     public function setQuantity(int $quantity): self;
 
+    public function equip(): self;
+
     /**
      * @return ItemData
      */

--- a/tests/Integration/Api/StoryApiTest.php
+++ b/tests/Integration/Api/StoryApiTest.php
@@ -78,7 +78,7 @@ class StoryApiTest extends TestCase
 
         //~ Both alive, should have no choices
         $edges = $story->getPossibleChoices('text_4', $player, $goblin);
-        self::assertCount(0, $edges);
+        self::assertCount(1, $edges);
 
         //~ Combat simulation, Player wins
         $goblin->getAbilities()->get('vitality')?->decrease(100);

--- a/tests/Unit/Element/Entity/EntityTest.php
+++ b/tests/Unit/Element/Entity/EntityTest.php
@@ -23,6 +23,8 @@ class EntityTest extends TestCase
     {
         $player = self::getPlayer();
 
+        $player->getInventory()->get('The Sword')?->equip();
+
         self::assertSame('Brave Test Hero #1', $player->getName());
         self::assertSame(24, $player->getAbilities()->get('vitality')?->getValue());
     }


### PR DESCRIPTION
- GameApi::read(): if source = target, do not apply the trigger (already be applied)
- Add ItemInterface::equip() method to equip an item
- Fix story test on condition for edge